### PR TITLE
data- can be used as dependencies source

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,15 @@ const content = fs.readFileSync("index.html", "utf8");
 // list the names of the used files (ex: 'foo.css', 'foo.png', etc)
 const dependencies = detective(content);
 ```
+### data-src
+
+In many cases, ```data-src,...``` are used to [lazy load images](https://stackoverflow.com/questions/12396068/speed-up-page-load-by-deferring-images)
+
+This is possible detective outputs such attributes by adding a list of html tags to add such attributes.
+
+```js
+const dependencies = detective(content, [ 'img', 'source' ]);
+```
 
 ### License
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const { debuglog } = require("util");
 const { parse } = require("parse5");
-const { traverse, defaultSources } = require("./utils");
+const { traverse, defaultSources, addDataSources } = require("./utils");
 
 const debug = debuglog("detective-html");
 
@@ -12,10 +12,12 @@ const debug = debuglog("detective-html");
  * @param  {String} fileContent
  * @return {String[]}
  */
-module.exports = function detective(fileContent) {
+module.exports = function detective(fileContent, listDatas = []) {
   if (typeof fileContent === "undefined") throw new Error("content not given");
   if (typeof fileContent !== "string")
     throw new Error("content is not a string");
+
+  addDataSources(listDatas)   // for ex: addDataSources(['source', 'img'])
 
   let dependencies = [];
   let ast = {};

--- a/test/data.html
+++ b/test/data.html
@@ -1,0 +1,17 @@
+<!doctype html>
+
+<img src="image1.png">
+<img src='small2.png' data-src="big3.webp">
+<img srcset=small4.png data-srcset=big5.webp>
+<img srcset=small6.png data-srcset=big7.webp data-custom="img/NOWAY1.jpg">
+
+<picture data-src="NOWAY2">
+  <source type="image/webp" data-srcset="img/big8.webp" media="(min-width: 513px)">
+  <source type="image/jpeg" data-srcset="img/big9.jpg"  media="(min-width: 513px)">
+  <source type="image/png"  data-srcset="img/big10.png"                   >
+  <img data-src="img/backup1.jpg" data-custom='NOWAY3.jpg' width="640" height="480" alt="Oh! My! God!">
+</picture>
+
+<video src="video1.ogg" data-src="NOWAY4.ogg" controls>
+  Your browser does not support the video tag.
+</video>

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -1,0 +1,37 @@
+/* eslint-env mocha */
+
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const assert = require("assert").strict;
+const detective = require("../index.js");
+
+function test(source, dependencies, options) {
+  assert.deepEqual(detective(source, options), dependencies);
+}
+
+describe("detective-html", () => {
+  describe("html", () => {
+    it("Dependencies with data-src and data-srcset on img and source", () => {
+      const htmlStr = fs
+        .readFileSync(path.join(__dirname, "data.html"), "utf8")
+        .toString();
+      test(htmlStr, [
+        'image1.png',
+        'small2.png',
+        'big3.webp',
+        'small4.png',
+        'big5.webp',
+        'small6.png',
+        'big7.webp',
+        'img/big8.webp',
+        'img/big9.jpg',
+        'img/big10.png',
+        'img/backup1.jpg',
+        'video1.ogg',
+        ],
+        [ 'img', 'source']);
+    });
+  });
+});

--- a/utils.js
+++ b/utils.js
@@ -728,69 +728,51 @@ function metaContentType(options) {
 //   ];
 // }
 
+// defaultSources is populated in addDataSources
+// it is required to repopulate it each time detective is called so that
+// it is possible to call detective the first time with data- list,
+// and the second time without
+const defaultSources = new Map()
 
-const defaultSources = new Map([["audio", new Map([["src", {
-  type: srcType
-}]])], ["embed", new Map([["src", {
-  type: srcType
-}]])], ["img", new Map([["src", {
-  type: srcType
-}], ["srcset", {
-  type: srcsetType
-}]])], ["input", new Map([["src", {
-  type: srcType
-}]])], ["link", new Map([["href", {
-  type: srcType,
-  filter: linkUnionFilter
-}], ["imagesrcset", {
-  type: srcsetType,
-  filter: linkHrefFilter
-}]])], ["meta", new Map([["content", {
-  type: metaContentType,
-  filter: metaContentFilter
-}]])], ["object", new Map([["data", {
-  type: srcType
-}]])], ["script", new Map([["src", {
-  type: srcType,
-  filter: scriptSrcFilter
-}], // Using href with <script> is described here: https://developer.mozilla.org/en-US/docs/Web/SVG/Element/script
-["href", {
-  type: srcType,
-  filter: scriptSrcFilter
-}], ["xlink:href", {
-  type: srcType,
-  filter: scriptSrcFilter
-}]])], ["source", new Map([["src", {
-  type: srcType
-}], ["srcset", {
-  type: srcsetType
-}]])], ["track", new Map([["src", {
-  type: srcType
-}]])], ["video", new Map([["poster", {
-  type: srcType
-}], ["src", {
-  type: srcType
-}]])], // SVG
-["image", new Map([["xlink:href", {
-  type: srcType
-}], ["href", {
-  type: srcType
-}]])], ["use", new Map([["xlink:href", {
-  type: srcType
-}], ["href", {
-  type: srcType
-}]])] // [
-//   'webpack-import',
-//   new Map([
-//     [
-//       'src',
-//       {
-//         type: webpackImportType,
-//       },
-//     ],
-//   ]),
-// ],
-]);
+// addDataSources(lSources):
+// Add to defaultSources 'data-' attributes to the sources in list
+// Example: addDataSources(['img', 'source']) adds data-src and data-srcset to this html sources
+//          in defaultSources
+function addDataSources(lSources) {
+  defaultSources.set("audio", new Map([["src", { type: srcType }]]))
+  defaultSources.set("embed", new Map([["src", { type: srcType }]]))
+  defaultSources.set("img", new Map([["src", { type: srcType }], ["srcset", { type: srcsetType }]]))
+  defaultSources.set("input", new Map([["src", { type: srcType }]]))
+  defaultSources.set("link", new Map([["href", { type: srcType, filter: linkUnionFilter }], ["imagesrcset", { type: srcsetType, filter: linkHrefFilter }]]))
+  defaultSources.set("meta", new Map([["content", { type: metaContentType, filter: metaContentFilter }]]))
+  defaultSources.set("object", new Map([["data", { type: srcType }]]))
+  defaultSources.set("script", new Map([["src", { type: srcType, filter: scriptSrcFilter }], ["href", { type: srcType, filter: scriptSrcFilter }], ["xlink:href", { type: srcType, filter: scriptSrcFilter }]]))
+  defaultSources.set("source", new Map([["src", { type: srcType }], ["srcset", { type: srcsetType }]]))
+  defaultSources.set("track", new Map([["src", { type: srcType }]]))
+  defaultSources.set("video", new Map([["poster", { type: srcType }], ["src", { type: srcType }]]))
+  defaultSources.set("image", new Map([["xlink:href", { type: srcType }], ["href", { type: srcType }]]))
+  defaultSources.set("use", new Map([["xlink:href", { type: srcType }], ["href", { type: srcType }]]))
+  // [
+  //   'webpack-import',
+  //   new Map([
+  //     [
+  //       'src',
+  //       {
+  //         type: webpackImportType,
+  //       },
+  //     ],
+  //   ]),
+  // ],
+
+  lSources.forEach(src => {
+    let defaultSrc = defaultSources.get(src)
+    let datas = []
+    defaultSrc.forEach((attr, key) => {
+      datas.push({ key: 'data-' + key, attr: attr})
+    })
+    datas.forEach(data => defaultSrc.set(data.key, data.attr))
+  })
+}
 
 function normalizeSourcesList(sources) {
   if (typeof sources === "undefined") {
@@ -1045,3 +1027,4 @@ function traverse(root, callback) {
 const webpackIgnoreCommentRegexp = /webpackIgnore:(\s+)?(true|false)/;
 exports.webpackIgnoreCommentRegexp = webpackIgnoreCommentRegexp;
 exports.defaultSources = defaultSources;
+exports.addDataSources = addDataSources


### PR DESCRIPTION
In many cases, ```data-src,...``` are used to [lazy load images](https://stackoverflow.com/questions/12396068/speed-up-page-load-by-deferring-images)

This is possible detective outputs such attributes by adding a list of html tags to add such attributes.

```js
const dependencies = detective(content, [ 'img', 'source' ]);
```
