### PR TITLE
Dependencies on non-standard attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,30 @@ const content = fs.readFileSync("index.html", "utf8");
 // list the names of the used files (ex: 'foo.css', 'foo.png', etc)
 const dependencies = detective(content);
 ```
+### Non-standard attributes
+
+In many cases, ```data-src,...``` are used to [lazy load images](https://stackoverflow.com/questions/12396068/speed-up-page-load-by-deferring-images)
+
+This is possible detective outputs such non-standard attribute dependencies by adding
+a list of html tags and associated specific attributes.
+The way it is provided is similar to what
+[webpack uses](https://webpack.js.org/loaders/html-loader/#object).
+
+```js
+const options = {
+  sources: {
+    list:
+      [
+        "...",
+        { tag: "img", attribute: "data-src", type: "src", },
+        { tag: "img", attribute: "data-srcset", type: "srcset", },
+        { tag: "source", attribute: "data-src", type: "src", },
+        { tag: "source", attribute: "data-srcset", type: "srcset", },
+      ]
+  }
+}
+const dependencies = detective(content, options);
+```
 
 ### License
 

--- a/test/data.html
+++ b/test/data.html
@@ -1,0 +1,17 @@
+<!doctype html>
+
+<img src="image1.png">
+<img src='small2.png' data-src="big3.webp">
+<img srcset=small4.png data-srcset=big5.webp>
+<img srcset=small6.png data-srcset=big7.webp data-custom="img/NOWAY1.jpg">
+
+<picture data-src="NOWAY2">
+  <source type="image/webp" data-srcset="img/big8.webp" media="(min-width: 513px)">
+  <source type="image/jpeg" data-srcset="img/big9.jpg"  media="(min-width: 513px)">
+  <source type="image/png"  data-srcset="img/big10.png"                   >
+  <img data-src="img/backup1.jpg" data-custom='NOWAY3.jpg' width="640" height="480" alt="Oh! My! God!">
+</picture>
+
+<video src="video1.ogg" data-src="NOWAY4.ogg" controls>
+  Your browser does not support the video tag.
+</video>

--- a/test/test-data.js
+++ b/test/test-data.js
@@ -1,0 +1,49 @@
+/* eslint-env mocha */
+
+"use strict";
+
+const path = require("path");
+const fs = require("fs");
+const assert = require("assert").strict;
+const detective = require("../index.js");
+
+function test(source, dependencies, options) {
+  assert.deepEqual(detective(source, options), dependencies);
+}
+
+describe("detective-html", () => {
+  describe("html", () => {
+    it("Dependencies with data-src and data-srcset on img and source", () => {
+      const htmlStr = fs
+        .readFileSync(path.join(__dirname, "data.html"), "utf8")
+        .toString();
+      const options = {
+        sources: {
+          list:
+            [
+              "...",
+              { tag: "img", attribute: "data-src", type: "src", },
+              { tag: "img", attribute: "data-srcset", type: "srcset", },
+              { tag: "source", attribute: "data-src", type: "src", },
+              { tag: "source", attribute: "data-srcset", type: "srcset", },
+            ]
+        }
+      }
+      test(htmlStr, [
+        'image1.png',
+        'small2.png',
+        'big3.webp',
+        'small4.png',
+        'big5.webp',
+        'small6.png',
+        'big7.webp',
+        'img/big8.webp',
+        'img/big9.jpg',
+        'img/big10.png',
+        'img/backup1.jpg',
+        'video1.ogg',
+      ],
+        options);
+    });
+  });
+});


### PR DESCRIPTION
In many cases, ```data-src,...``` are used to [lazy load images](https://stackoverflow.com/questions/12396068/speed-up-page-load-by-deferring-images)

This is possible detective outputs such non-standard attribute dependencies by adding a list of html tags and associated specific attributes. The way it is provided is similar to what
[webpack uses](https://webpack.js.org/loaders/html-loader/#object).